### PR TITLE
feature: Only install when not already installed

### DIFF
--- a/.github/workflows/test__ensure_uv_installed.yml
+++ b/.github/workflows/test__ensure_uv_installed.yml
@@ -1,0 +1,22 @@
+# Tests for ensure_uv_installed, which are difficult to write as unit tests because they depend on machine state that will be modified be the tests start
+
+name: Test ensure_uv_installed
+
+on:
+  - push
+  - pull_request
+  - workflow_dispatch
+
+jobs:
+  test__ensure_uv_installed:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./test__ensure_uv_installed

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,2 @@
+TODO:
+- if curl is not installed, use wget

--- a/ensure_uv_installed.cmd
+++ b/ensure_uv_installed.cmd
@@ -7,3 +7,6 @@ if ERRORLEVEL 1 (
     set "PsModulePath="
     powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex" || goto :ERROR
 )
+
+    :ERROR
+cmd.exe /c exit /b %ERRORLEVEL%

--- a/ensure_uv_installed.cmd
+++ b/ensure_uv_installed.cmd
@@ -1,6 +1,9 @@
 @echo off
 setlocal
 
-@REM Clear PsModulePath to avoid conflicts with PWSH, which happens in GitHub actions
-set "PsModulePath="
-powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex" || goto :ERROR
+where /q uv
+if ERRORLEVEL 1 (
+    @REM Clear PsModulePath to avoid conflicts with PWSH, which happens in GitHub actions
+    set "PsModulePath="
+    powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex" || goto :ERROR
+)

--- a/ensure_uv_installed.sh
+++ b/ensure_uv_installed.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-curl -LsSf https://astral.sh/uv/install.sh | sh
+if ! command -v uv; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi

--- a/test__ensure_uv_installed
+++ b/test__ensure_uv_installed
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+# should not have uv installed yet
+command -v uv && (echo "delete ~/.local before running this test" && exit 1)
+
+# call ensure_uv_installed and check if it downloads uv
+./ensure_uv_installed.sh 2>&1 | grep '^downloading uv' || exit 1
+
+export PATH="$HOME/.local/bin:$PATH"
+command -v uv || exit 1
+
+# should not install uv again - no sign of `downloading uv`
+./ensure_uv_installed.sh 2>&1 | grep -v '^downloading uv' || exit 1
+

--- a/test__ensure_uv_installed.cmd
+++ b/test__ensure_uv_installed.cmd
@@ -1,0 +1,19 @@
+setlocal
+
+@REM should not have uv installed yet
+where /q uv
+if not ERRORLEVEL 1 (
+  echo delete ^%USERPROFILE^%\.local before running this test
+  exit /b 1
+)
+
+@REM call ensure_uv_installed and check if it downloads uv
+call ensure_uv_installed.cmd 2>&1 | findstr /b /c:"Downloading uv"
+if ERRORLEVEL 1 exit /b 1
+
+set "PATH=%USERPROFILE%\.local\bin;%PATH%"
+where /q uv || exit /b 1
+
+@REM should not install uv again
+call ensure_uv_installed.cmd 2>&1 | findstr /b /c:"Downloading uv"
+if not ERRORLEVEL 1 exit /b 1


### PR DESCRIPTION
## Summary by Sourcery

Modify installation scripts to check for the presence of 'uv' before attempting installation, preventing redundant installations. Add a GitHub Actions workflow to test the installation script on multiple operating systems and introduce a test script to verify the installation logic. Include a TODO note for potential future improvements regarding the use of 'wget'.

New Features:
- Add a check to ensure 'uv' is only installed if not already present on the system.

CI:
- Introduce a new GitHub Actions workflow to test the 'ensure_uv_installed' script across different operating systems.

Tests:
- Add a new test script 'test__ensure_uv_installed.cmd' to verify the installation behavior of 'uv', ensuring it installs only when not already present.

Chores:
- Add a TODO file to consider using 'wget' if 'curl' is not installed.