### PR TITLE
. e use `python3` on Mac/Linux

### DIFF
--- a/build_and_test
+++ b/build_and_test
@@ -1,6 +1,6 @@
 #! /bin/bash
 set -euo pipefail
 
-python --version
-python -m pip install --upgrade pip --requirement requirements.dev.txt
-python -m pytest . -v
+python3 --version
+python3 -m pip install --upgrade pip --requirement requirements.dev.txt
+python3 -m pytest . -v


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update build script to use `python3` instead of default Python interpreter